### PR TITLE
Antipode

### DIFF
--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::AntipodeController < ApplicationController
+  def show
+    look_up_params['loc']
+    binding.pry
+  end
+
+  private
+  def look_up_params
+    params.permit(:loc)
+  end
+end

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -8,11 +8,11 @@ class Api::V1::AntipodeController < ApplicationController
     antipode_long = AmypodeService.new(lat, long).antipode_long
 
     forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
-    forecast = Forecast.new(forecast_data)
+    antipode_forecast = Forecast.new(forecast_data)
 
     antipode_city_name = ReverseGeocodingService.new(antipode_lat, antipode_long).city
 
-    antipode = Antipode.new(look_up_city, antipode_city_name, forecast)
+    antipode = Antipode.new(look_up_city, antipode_city_name, antipode_forecast)
 
     render json: AntipodeSerializer.new(antipode)
   end

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -1,21 +1,6 @@
 class Api::V1::AntipodeController < ApplicationController
   def show
-    # look_up_city = look_up_params['loc']
-    # lat = LocationService.new(look_up_city).lat
-    # long = LocationService.new(look_up_city).long
-    #
-    # antipode_lat = AmypodeService.new(lat, long).antipode_lat
-    # antipode_long = AmypodeService.new(lat, long).antipode_long
-    #
-    # forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
-    # antipode_forecast = Forecast.new(forecast_data)
-    #
-    # antipode_city_name = ReverseGeocodingService.new(antipode_lat, antipode_long).city
-    #
-    # antipode = Antipode.new(look_up_city, antipode_city_name, antipode_forecast)
-
     antipode = AntipodeFacade.new(look_up_params['loc']).antipode
-    #outputs antipode object
 
     render json: AntipodeSerializer.new(antipode)
   end

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::AntipodeController < ApplicationController
   def show
     look_up_city = look_up_params['loc']
-    lat = ReverseGeocodingService.new(look_up_city).lat
-    long = ReverseGeocodingService.new(look_up_city).long
+    lat = LocationService.new(look_up_city).lat
+    long = LocationService.new(look_up_city).long
 
     antipode = AmypodeService.new(lat, long).antipode
 

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -22,5 +22,3 @@ class Api::V1::AntipodeController < ApplicationController
     params.permit(:loc)
   end
 end
-
-# render json: ForecastSerializer.new(Forecast.new(forecast_data))

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -1,18 +1,21 @@
 class Api::V1::AntipodeController < ApplicationController
   def show
-    look_up_city = look_up_params['loc']
-    lat = LocationService.new(look_up_city).lat
-    long = LocationService.new(look_up_city).long
+    # look_up_city = look_up_params['loc']
+    # lat = LocationService.new(look_up_city).lat
+    # long = LocationService.new(look_up_city).long
+    #
+    # antipode_lat = AmypodeService.new(lat, long).antipode_lat
+    # antipode_long = AmypodeService.new(lat, long).antipode_long
+    #
+    # forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
+    # antipode_forecast = Forecast.new(forecast_data)
+    #
+    # antipode_city_name = ReverseGeocodingService.new(antipode_lat, antipode_long).city
+    #
+    # antipode = Antipode.new(look_up_city, antipode_city_name, antipode_forecast)
 
-    antipode_lat = AmypodeService.new(lat, long).antipode_lat
-    antipode_long = AmypodeService.new(lat, long).antipode_long
-
-    forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
-    antipode_forecast = Forecast.new(forecast_data)
-
-    antipode_city_name = ReverseGeocodingService.new(antipode_lat, antipode_long).city
-
-    antipode = Antipode.new(look_up_city, antipode_city_name, antipode_forecast)
+    antipode = AntipodeFacade.new(look_up_params['loc']).antipode
+    #outputs antipode object
 
     render json: AntipodeSerializer.new(antipode)
   end

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -1,7 +1,16 @@
 class Api::V1::AntipodeController < ApplicationController
   def show
-    look_up_params['loc']
-    binding.pry
+    look_up_city = look_up_params['loc']
+    lat = ReverseGeocodingService.new(look_up_city).lat
+    long = ReverseGeocodingService.new(look_up_city).long
+
+    antipode = AmypodeService.new(lat, long).antipode
+
+    forecast_data = ForecastFacade.new(antipode).forecast
+
+    # render json: ForecastSerializer.new(Forecast.new(forecast_data))
+
+    render json: AntipodeSerializer.new(look_up_city, forecast_data)
   end
 
   private

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -4,13 +4,15 @@ class Api::V1::AntipodeController < ApplicationController
     lat = LocationService.new(look_up_city).lat
     long = LocationService.new(look_up_city).long
 
-    antipode = AmypodeService.new(lat, long).antipode
+    antipode_lat = AmypodeService.new(lat, long).antipode_lat
+    antipode_long = AmypodeService.new(lat, long).antipode_long
 
-    forecast_data = ForecastFacade.new(antipode).forecast
+    forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
+    forecast = Forecast.new(forecast_data)
 
-    # render json: ForecastSerializer.new(Forecast.new(forecast_data))
+    antipode_name = ReverseGeocodingService.new(antipode_lat, antipode_long)
 
-    render json: AntipodeSerializer.new(look_up_city, forecast_data)
+    render json: AntipodeSerializer.new(look_up_city, antipode_name, forecast)
   end
 
   private
@@ -18,3 +20,5 @@ class Api::V1::AntipodeController < ApplicationController
     params.permit(:loc)
   end
 end
+
+# render json: ForecastSerializer.new(Forecast.new(forecast_data))

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -10,9 +10,9 @@ class Api::V1::AntipodeController < ApplicationController
     forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
     forecast = Forecast.new(forecast_data)
 
-    antipode_name = ReverseGeocodingService.new(antipode_lat, antipode_long)
+    antipode_city_name = ReverseGeocodingService.new(antipode_lat, antipode_long).city
 
-    render json: AntipodeSerializer.new(look_up_city, antipode_name, forecast)
+    render json: AntipodeSerializer.new(look_up_city, antipode_city_name, forecast)
   end
 
   private

--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -12,7 +12,9 @@ class Api::V1::AntipodeController < ApplicationController
 
     antipode_city_name = ReverseGeocodingService.new(antipode_lat, antipode_long).city
 
-    render json: AntipodeSerializer.new(look_up_city, antipode_city_name, forecast)
+    antipode = Antipode.new(look_up_city, antipode_city_name, forecast)
+
+    render json: AntipodeSerializer.new(antipode)
   end
 
   private

--- a/app/facades/antipode_facade.rb
+++ b/app/facades/antipode_facade.rb
@@ -1,0 +1,20 @@
+class AntipodeFacade
+  def initialize(look_up_city)
+    @look_up_city = look_up_city
+  end
+
+  def antipode
+    lat = LocationService.new(@look_up_city).lat
+    long = LocationService.new(@look_up_city).long
+
+    antipode_lat = AmypodeService.new(lat, long).antipode_lat
+    antipode_long = AmypodeService.new(lat, long).antipode_long
+
+    forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
+    antipode_forecast = Forecast.new(forecast_data)
+
+    antipode_city_name = ReverseGeocodingService.new(antipode_lat, antipode_long).city
+
+    Antipode.new(@look_up_city, antipode_city_name, antipode_forecast)
+  end
+end

--- a/app/models/antipode.rb
+++ b/app/models/antipode.rb
@@ -2,9 +2,19 @@ class Antipode
   def initialize(look_up_city, antipode_city_name, antipode_forecast)
     @look_up_city = look_up_city
     @antipode_city_name = antipode_city_name
-    @antipode_city_name = antipode_city_name
-    binding.pry
+    @antipode_forecast = antipode_forecast
   end
 
+  def location_name
+    @antipode_city_name
+  end
 
+  def forecast
+    {summary: @antipode_forecast.current_summary,
+      current_temperature: @antipode_forecast.current_temperature}
+  end
+
+  def search_location
+    @look_up_city
+  end
 end

--- a/app/models/antipode.rb
+++ b/app/models/antipode.rb
@@ -1,0 +1,10 @@
+class Antipode
+  def initialize(look_up_city, antipode_city_name, antipode_forecast)
+    @look_up_city = look_up_city
+    @antipode_city_name = antipode_city_name
+    @antipode_city_name = antipode_city_name
+    binding.pry
+  end
+
+
+end

--- a/app/models/antipode.rb
+++ b/app/models/antipode.rb
@@ -5,6 +5,10 @@ class Antipode
     @antipode_forecast = antipode_forecast
   end
 
+  def id
+    "#{@antipode_forecast.current_time}/" + "#{@antipode_forecast.lat}/" + "#{@antipode_forecast.long}"
+  end
+
   def location_name
     @antipode_city_name
   end

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -8,6 +8,14 @@ class Forecast
     "#{current_time}/" + "#{@forecast_data[:latitude]}/" + "#{@forecast_data[:longitude]}"
   end
 
+  def lat
+    @forecast_data[:latitude]
+  end
+
+  def long
+    @forecast_data[:longitude]
+  end
+
   def current_weather
     @forecast_data[:currently]
   end

--- a/app/serializers/antipode_serializer.rb
+++ b/app/serializers/antipode_serializer.rb
@@ -1,0 +1,5 @@
+class AntipodeSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes  :id
+
+end

--- a/app/serializers/antipode_serializer.rb
+++ b/app/serializers/antipode_serializer.rb
@@ -1,5 +1,7 @@
 class AntipodeSerializer
   include FastJsonapi::ObjectSerializer
-  attributes  :id
-
+  attributes  :id,
+              :location_name,
+              :forecast,
+              :search_location
 end

--- a/app/services/amypode_service.rb
+++ b/app/services/amypode_service.rb
@@ -6,7 +6,22 @@ class AmypodeService
   end
 
   def antipode
-    conn.get('')
-    parse(reponse)
+    response = conn.get("/api/v1/antipodes?lat=#{@lat}&long=#{@long}")
+    parse(response)
+  end
+
+  def antipode_lat
+    antipode[:data][:attributes][:lat]
+  end
+
+  def antipode_long
+    antipode[:data][:attributes][:long]
+  end
+
+  def conn
+    Faraday.new(url: 'http://amypode.herokuapp.com') do |faraday|
+      faraday.headers['api_key'] = ENV['amypode_key']
+      faraday.adapter Faraday.default_adapter
+    end
   end
 end

--- a/app/services/amypode_service.rb
+++ b/app/services/amypode_service.rb
@@ -1,0 +1,12 @@
+class AmypodeService
+  include Service
+  def initialize(lat, long)
+    @lat = lat
+    @long = long
+  end
+
+  def antipode
+    conn.get('')
+    parse(reponse)
+  end
+end

--- a/app/services/reverse_geocoding_service.rb
+++ b/app/services/reverse_geocoding_service.rb
@@ -6,7 +6,7 @@ class ReverseGeocodingService
     @long = long
   end
 
-# go back and make city object for the parsed response
+# go back and make city object for the parsed response (result)
   def city
     response = conn.get('/maps/api/geocode/json')
     result = parse(response)
@@ -14,7 +14,7 @@ class ReverseGeocodingService
   end
 
   def parse_city(result)
-    result
+    result[:results][1][:formatted_address]
   end
 
   def location_params

--- a/app/services/reverse_geocoding_service.rb
+++ b/app/services/reverse_geocoding_service.rb
@@ -6,7 +6,6 @@ class ReverseGeocodingService
     @long = long
   end
 
-# go back and make city object for the parsed response (result)
   def city
     response = conn.get('/maps/api/geocode/json')
     result = parse(response)

--- a/app/services/reverse_geocoding_service.rb
+++ b/app/services/reverse_geocoding_service.rb
@@ -1,0 +1,31 @@
+class ReverseGeocodingService
+  include Service
+
+  def initialize(lat, long)
+    @lat = lat
+    @long = long
+  end
+
+# go back and make city object for the parsed response
+  def city
+    response = conn.get('/maps/api/geocode/json')
+    result = parse(response)
+    parse_city(result)
+  end
+
+  def parse_city(result)
+    result
+  end
+
+  def location_params
+    @lat.to_s + ',' + @long.to_s
+  end
+
+  def conn
+    Faraday.new(url: 'https://maps.googleapis.com') do |faraday|
+      faraday.params[:key] = ENV['google_maps_key']
+      faraday.params[:latlng] = location_params
+      faraday.adapter  Faraday.default_adapter
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/backgrounds', to: 'backgrounds#show'
       post '/users', to: 'users#create'
       post '/sessions', to: 'sessions#create'
+      get '/antipode', to: 'antipode#show'
     end
   end
 end

--- a/spec/models/antipode_spec.rb
+++ b/spec/models/antipode_spec.rb
@@ -5,17 +5,17 @@ describe Antipode, type: :model do
   antipode_long = -65.8306389
 
   forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
-  @forecast = Forecast.new(forecast_data)
+  @antipode_forecast = Forecast.new(forecast_data)
   @look_up_city = "hongkong"
   @antipode_city_name = "Jujuy, Argentina"
 
   it 'exists' do
-    antipode = Antipode.new(@look_up_city, @antipode_city_name, @forecast)
+    antipode = Antipode.new(@look_up_city, @antipode_city_name, @antipode_forecast)
 
     expect(antipode).to be_a(Antipode)
   end
 
-  it '' do
+  it 'has attributes' do
 
   end
 end

--- a/spec/models/antipode_spec.rb
+++ b/spec/models/antipode_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Antipode, type: :model do
+  antipode_lat = -22.3193039
+  antipode_long = -65.8306389
+
+  forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
+  @forecast = Forecast.new(forecast_data)
+  @look_up_city = "hongkong"
+  @antipode_city_name = "Jujuy, Argentina"
+
+  it 'exists' do
+    antipode = Antipode.new(@look_up_city, @antipode_city_name, @forecast)
+
+    expect(antipode).to be_a(Antipode)
+  end
+
+  it '' do
+
+  end
+end

--- a/spec/models/antipode_spec.rb
+++ b/spec/models/antipode_spec.rb
@@ -1,22 +1,38 @@
 require 'rails_helper'
 
 describe Antipode, type: :model do
-  antipode_lat = -22.3193039
-  antipode_long = -65.8306389
+  before :each do
+    antipode_lat = -22.3193039
+    antipode_long = -65.8306389
 
-  forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
-  @antipode_forecast = Forecast.new(forecast_data)
-  @look_up_city = "hongkong"
-  @antipode_city_name = "Jujuy, Argentina"
+    @forecast_data = ForecastService.new(antipode_lat, antipode_long).forecast
+    @antipode_forecast = Forecast.new(@forecast_data)
+    @look_up_city = "hongkong"
+    @antipode_city_name = "Jujuy, Argentina"
 
-  it 'exists' do
-    antipode = Antipode.new(@look_up_city, @antipode_city_name, @antipode_forecast)
-
-    expect(antipode).to be_a(Antipode)
+    @antipode = Antipode.new(@look_up_city, @antipode_city_name, @antipode_forecast)
   end
 
-  xit 'has attributes' do
-    # test the other methods
-    # also add forecast methods for lat and long and change the id for forecast to use those methods
+  it 'exists' do
+    expect(@antipode).to be_a(Antipode)
+  end
+
+  it 'id' do
+    expect(@antipode.id).to be_a(String)
+  end
+
+  it 'location_name' do
+    expect(@antipode.location_name).to eq(@antipode_city_name)
+  end
+
+  it 'forecast' do
+    forecast = {summary: @antipode_forecast.current_summary,
+      current_temperature: @antipode_forecast.current_temperature}
+
+    expect(@antipode.forecast).to eq(forecast)
+  end
+
+  it 'search_location' do
+    expect(@antipode.search_location).to eq(@look_up_city)
   end
 end

--- a/spec/models/antipode_spec.rb
+++ b/spec/models/antipode_spec.rb
@@ -15,7 +15,8 @@ describe Antipode, type: :model do
     expect(antipode).to be_a(Antipode)
   end
 
-  it 'has attributes' do
-
+  xit 'has attributes' do
+    # test the other methods
+    # also add forecast methods for lat and long and change the id for forecast to use those methods
   end
 end

--- a/spec/models/forecast_spec.rb
+++ b/spec/models/forecast_spec.rb
@@ -14,6 +14,14 @@ describe 'Forecast', type: :model do
     expect(@forecast.id).to be_a(String)
   end
 
+  it '#lat' do
+    expect(@forecast.lat).to eq(39.7392358)
+  end
+
+  it '#long' do
+    expect(@forecast.long).to eq(-104.990251)
+  end
+
   context 'current' do
     it '#current_weather' do
       current_weather = @forecast.current_weather

--- a/spec/requests/api/v1/antipode_request.rb
+++ b/spec/requests/api/v1/antipode_request.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe 'Antipode API' do
+  it "receives the location and outputs that location, the anitpode & the antipode's forecast" do
+
+    get `/api/v1/antipode?loc=hongkong`
+
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    attributes = result[:data][:attributes]
+
+    expect(response).to be_succesful
+    expect(result[:data][:type]).to eq('antipode')
+    expect(attributes).to be_a(Hash)
+    expect(attributes).to have_key(:location_name)
+    expect(attributes).to have_key(:forecast)
+    expect(attributes[:forecast]).to have_key(:summary)
+    expect(attributes[:forecast]).to have_key(:current_temperature)
+
+    expect(result[:data]).to have_key(:search_location)
+    expect(result[:data][:search_location]).to eq('Hong Kong')
+  end
+end
+
+
+# An antipode is the point on the planet that is diametrically opposite.
+
+# You will create an endpoint like so:, `/api/v1/antipode?loc=hongkong`
+#
+# You will use the `Amypode API` to determine the antipode for Hong Kong.
+#
+# [`http://amypode.herokuapp.com/api/v1/antipodes?lat=27&long=-82`]
+#
+# This is a sample request. Amypode API requires header based authentication. It expects the  `api_key` header to be set to your key, which is `oscar_the_grouch`
+#
+# Your endpoint will give the user the original city, and the antipode’s location name and its current weather summary and current temperature in a format like this:
+#
+# ```
+# {
+#     "data": [
+#         {
+#             "id": "1",
+#             "type": "antipode",
+#             "attributes": {
+#                 "location_name": "Antipode City Name",
+#                 "forecast": {
+#                     "summary": "Mostly Cloudy,
+#                     "current_temperature": "72",
+#                 				},
+#             "search_location": "Hong Kong"
+#             }
+#         }
+#     ]
+# }
+# ```

--- a/spec/requests/api/v1/antipode_request_spec.rb
+++ b/spec/requests/api/v1/antipode_request_spec.rb
@@ -17,8 +17,8 @@ describe 'Antipode API' do
     expect(attributes[:forecast]).to have_key(:summary)
     expect(attributes[:forecast]).to have_key(:current_temperature)
 
-    expect(result[:data]).to have_key(:search_location)
-    expect(result[:data][:search_location]).to eq('Hong Kong')
+    expect(attributes).to have_key(:search_location)
+    expect(attributes[:search_location]).to eq('hongkong')
   end
 end
 

--- a/spec/requests/api/v1/antipode_request_spec.rb
+++ b/spec/requests/api/v1/antipode_request_spec.rb
@@ -9,7 +9,7 @@ describe 'Antipode API' do
 
     attributes = result[:data][:attributes]
 
-    expect(response).to be_succesful
+    expect(response).to be_successful
     expect(result[:data][:type]).to eq('antipode')
     expect(attributes).to be_a(Hash)
     expect(attributes).to have_key(:location_name)

--- a/spec/requests/api/v1/antipode_request_spec.rb
+++ b/spec/requests/api/v1/antipode_request_spec.rb
@@ -21,35 +21,3 @@ describe 'Antipode API' do
     expect(attributes[:search_location]).to eq('hongkong')
   end
 end
-
-
-# An antipode is the point on the planet that is diametrically opposite.
-
-# You will create an endpoint like so:, `/api/v1/antipode?loc=hongkong`
-#
-# You will use the `Amypode API` to determine the antipode for Hong Kong.
-#
-# [`http://amypode.herokuapp.com/api/v1/antipodes?lat=27&long=-82`]
-#
-# This is a sample request. Amypode API requires header based authentication. It expects the  `api_key` header to be set to your key, which is `oscar_the_grouch`
-#
-# Your endpoint will give the user the original city, and the antipode’s location name and its current weather summary and current temperature in a format like this:
-#
-# ```
-# {
-#     "data": [
-#         {
-#             "id": "1",
-#             "type": "antipode",
-#             "attributes": {
-#                 "location_name": "Antipode City Name",
-#                 "forecast": {
-#                     "summary": "Mostly Cloudy,
-#                     "current_temperature": "72",
-#                 				},
-#             "search_location": "Hong Kong"
-#             }
-#         }
-#     ]
-# }
-# ```

--- a/spec/requests/api/v1/antipode_request_spec.rb
+++ b/spec/requests/api/v1/antipode_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Antipode API' do
   it "receives the location and outputs that location, the anitpode & the antipode's forecast" do
 
-    get `/api/v1/antipode?loc=hongkong`
+    get '/api/v1/antipode?loc=hongkong'
 
     result = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/services/amypode_service_spec.rb
+++ b/spec/services/amypode_service_spec.rb
@@ -12,9 +12,20 @@ describe AmypodeService do
     expect(amypode_service).to be_a(AmypodeService)
   end
 
+
   it '#antipode -> receives lat and long and returns the antipode' do
+    response = {:data=>{:id=>'1', :type=>'antipode', :attributes=>{:lat=>-27.0, :long=>98.0}}}
+
     antipode = AmypodeService.new(@lat, @long).antipode
 
-    expect(antipode).to eq('Some Antipode City Name')
+    expect(antipode).to eq(response)
+  end
+
+  it '#antipode -> receives lat and long and returns the antipode lat & long' do
+    lat = AmypodeService.new(@lat, @long).antipode_lat
+    long = AmypodeService.new(@lat, @long).antipode_long
+
+    expect(lat).to eq(-27.0)
+    expect(long).to eq(98.0)
   end
 end

--- a/spec/services/amypode_service_spec.rb
+++ b/spec/services/amypode_service_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe LocationService do
+  before :each do
+    @lat = 27
+    @long = -82
+  end
+
+  it 'exists' do
+    amypode_service = AmypodeService.new(@lat, @long)
+
+    expect(amypode_service).to be_a(AmypodeService)
+  end
+
+  it '#antipode -> receives lat and long and returns the antipode' do
+    antipode = AmypodeService.new(@lat, @long).antipode
+
+    expect(antipode).to eq('Some Antipode City Name')
+  end
+end

--- a/spec/services/amypode_service_spec.rb
+++ b/spec/services/amypode_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe LocationService do
+describe AmypodeService do
   before :each do
     @lat = 27
     @long = -82

--- a/spec/services/reverse_geocoding_service_spec.rb
+++ b/spec/services/reverse_geocoding_service_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe ReverseGeocodingService do
+  before :each do
+    @antipode_lat = -22.3193039
+    @antipode_long = -65.8306389
+  end
+
+  it 'exists' do
+    reverse_geocoding_service = ReverseGeocodingService.new(@antipode_lat, @antipode_long)
+
+    expect(reverse_geocoding_service).to be_a(ReverseGeocodingService)
+  end
+
+  it '#city -> receives a lat and long and returns a city' do
+    city = ReverseGeocodingService.new(@antipode_lat, @antipode_long).city
+
+    expect(city).to eq("Something like La Paz")
+  end
+end

--- a/spec/services/reverse_geocoding_service_spec.rb
+++ b/spec/services/reverse_geocoding_service_spec.rb
@@ -15,6 +15,6 @@ describe ReverseGeocodingService do
   it '#city -> receives a lat and long and returns a city' do
     city = ReverseGeocodingService.new(@lat, @long).city
 
-    expect(city).to eq("Something like La Paz")
+    expect(city).to eq('Jujuy, Argentina')
   end
 end

--- a/spec/services/reverse_geocoding_service_spec.rb
+++ b/spec/services/reverse_geocoding_service_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 describe ReverseGeocodingService do
   before :each do
-    @antipode_lat = -22.3193039
-    @antipode_long = -65.8306389
+    @lat = -22.3193039
+    @long = -65.8306389
   end
 
   it 'exists' do
-    reverse_geocoding_service = ReverseGeocodingService.new(@antipode_lat, @antipode_long)
+    reverse_geocoding_service = ReverseGeocodingService.new(@lat, @long)
 
     expect(reverse_geocoding_service).to be_a(ReverseGeocodingService)
   end
 
   it '#city -> receives a lat and long and returns a city' do
-    city = ReverseGeocodingService.new(@antipode_lat, @antipode_long).city
+    city = ReverseGeocodingService.new(@lat, @long).city
 
     expect(city).to eq("Something like La Paz")
   end


### PR DESCRIPTION
This branch completes the following specifications:

## Antipodes

An antipode is the point on the planet that is diametrically opposite. 

You will create an endpoint like so:, `/api/v1/antipode?loc=hongkong`

You will use the `Amypode API` to determine the antipode for Hong Kong.

[`http://amypode.herokuapp.com/api/v1/antipodes?lat=27&long=-82`]

This is a sample request. Amypode API requires header based authentication. It expects the  `api_key` header to be set to your key, which is `oscar_the_grouch`

Your endpoint will give the user the original city, and the antipode’s location name and its current weather summary and current temperature in a format like this:

```
{
    "data": [
        {
            "id": "1",
            "type": "antipode",
            "attributes": {
                "location_name": "Antipode City Name",
                "forecast": {
                    "summary": "Mostly Cloudy,
                    "current_temperature": "72",
                				},
            "search_location": "Hong Kong"
            }
        }
    ]
}
```