### PR TITLE
Iteration 4 favoriting locations

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::BackgroundsController < ApplicationController
+class Api::V1::BackgroundsController < ApiController
   def show
     background_data = BackgroundService.new(look_up_params).images
     render json: BackgroundSerializer.new(Background.new(background_data))

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::FavoritesController < ApplicationController
+  def create
+    user = User.find_by(api_key: favorite_params[:api_key])
+
+    if user
+      FavoriteCity.create(user: user, city: favorite_params[:location])
+    else
+      render json: {}, status: 401
+    end
+  end
+
+  private
+  def favorite_params
+    params.permit(:location, :api_key)
+  end
+end

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::FavoritesController < ApplicationController
+class Api::V1::FavoritesController < ApiController
   def create
     user = User.find_by(api_key: favorite_params[:api_key])
 

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,16 +1,15 @@
 class Api::V1::FavoritesController < ApiController
   def create
-    user = User.find_by(api_key: favorite_params[:api_key])
-
+    user = User.find_by(api_key: json_body[:api_key])
     if user
-      FavoriteCity.create(user: user, city: favorite_params[:location])
+      FavoriteCity.create(user: user, city: json_body[:location])
     else
       render json: {}, status: 401
     end
   end
 
   private
-  def favorite_params
-    params.permit(:location, :api_key)
+  def json_body
+    JSON.parse(request.raw_post, symbolize_names: true)
   end
 end

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::ForecastController < ApplicationController
+class Api::V1::ForecastController < ApiController
   def show
     forecast_data = ForecastFacade.new(look_up_params).forecast
     render json: ForecastSerializer.new(Forecast.new(forecast_data))

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::SessionsController < ApplicationController
+class Api::V1::SessionsController < ApiController
   def create
     user = User.find_by(email: login_params['email'])
     authenticate_then_render(user)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::UsersController < ApplicationController
+class Api::V1::UsersController < ApiController
   def create
     user = User.new(email: input_params['email'],
                     password: input_params['password'],

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,3 @@
+class ApiController < ApplicationController
+  protect_from_forgery with: :null_session
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,3 +1,4 @@
 class ApiController < ApplicationController
   protect_from_forgery with: :null_session
+  # skip_before_action :verify_authenticity_token
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :null_session
 end

--- a/app/models/favorite_city.rb
+++ b/app/models/favorite_city.rb
@@ -1,0 +1,4 @@
+class FavoriteCity < ApplicationRecord
+  belongs_to :user
+  validates_presence_of :user, :city
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :favorite_cities
   validates :email, presence: true, uniqueness: true
   validates_presence_of :password_digest, :api_key
   has_secure_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/backgrounds', to: 'backgrounds#show'
       post '/users', to: 'users#create'
       post '/sessions', to: 'sessions#create'
+      post '/favorites', to: 'favorites#create'
     end
   end
 end

--- a/db/migrate/20190414150240_create_users.rb
+++ b/db/migrate/20190414150240_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsersTable < ActiveRecord::Migration[5.2]
+class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       t.string :email

--- a/db/migrate/20190414205847_create_favorite_cities.rb
+++ b/db/migrate/20190414205847_create_favorite_cities.rb
@@ -1,0 +1,8 @@
+class CreateFavoriteCities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :favorite_cities do |t|
+      t.references :user, foreign_key: true
+      t.string :city
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_14_150240) do
+ActiveRecord::Schema.define(version: 2019_04_14_205847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "favorite_cities", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "city"
+    t.index ["user_id"], name: "index_favorite_cities_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email"
@@ -23,4 +29,5 @@ ActiveRecord::Schema.define(version: 2019_04_14_150240) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "favorite_cities", "users"
 end

--- a/spec/models/favorite_city_spec.rb
+++ b/spec/models/favorite_city_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe FavoriteCity, type: :model do
+  context 'Validations' do
+    it { should validate_presence_of(:user) }
+    it { should validate_presence_of(:city) }
+  end
+
+  context 'Relationships' do
+    it { should belong_to(:user) }
+  end
+
+  it 'exists & has attributes' do
+    email = 'email'
+    password = 'password123'
+    api_key = "jgn983hy48thw9begh98h4539h4"
+
+    user = User.create!(email: email, password: password, password_confirmation: password, api_key: api_key)
+
+    city = "Denver, CO"
+    favorite = FavoriteCity.create(user: user, city: city)
+
+    expect(favorite).to be_a(FavoriteCity)
+    expect(user.favorite_cities[0].city).to eq(city)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe User, type: :model do
   it 'exists' do
-    user = User.new( email: 'email', password: 'password123', password_confirmation: 'password123' )
+    user = User.new(email: 'email', password: 'password123', password_confirmation: 'password123')
 
     expect(user).to be_a(User)
   end
@@ -14,10 +14,14 @@ describe User, type: :model do
     it { should validate_presence_of(:api_key) }
   end
 
+  context 'Relationships' do
+    it { should have_many(:favorite_cities) }
+  end
+
   it 'has attributes' do
     email = 'email'
     password = 'password123'
-    User.create!( email: email, password: password, password_confirmation: password, api_key: ApiKey.new.key )
+    User.create!(email: email, password: password, password_confirmation: password, api_key: ApiKey.new.key)
 
     expect(User.last.email).to eq(email)
     expect(User.last.password_digest).to be_a(String)

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -11,10 +11,9 @@ describe 'Favorite Location API' do
   end
 
   it "receives a location & API key, then saves the location as the user's favorite" do
-    favorite_params = {"location": @city,
-                        "api_key": @api_key}
+    body = "{ \"location\": \"#{@city}\", \"api_key\": \"#{@api_key}\"}"
 
-    post '/api/v1/favorites', params: favorite_params
+    post '/api/v1/favorites', params: body
 
     expect(response.status).to eq(204)
     expect(@user1.favorite_cities[0].city).to eq(@city)
@@ -22,18 +21,17 @@ describe 'Favorite Location API' do
   end
 
   it "receives a location & an incorrect API key, and does not save the location as a user's favorite" do
-    favorite_params = {"location": @city,
-                        "api_key": "incorrect-key"}
+    body = "{ \"location\": \"#{@city}\", \"api_key\": \"incorrect-key\"}"
 
-    post '/api/v1/favorites', params: favorite_params
+    post '/api/v1/favorites', params: body
 
     expect(response.status).to eq(401)
   end
 
   it "receives a location, but no API key, and does not save the location as a user's favorite" do
-    favorite_params = {"location": @city}
+    body = "{ \"location\": \"#{@city}\"}"
 
-    post '/api/v1/favorites', params: favorite_params
+    post '/api/v1/favorites', params: body
 
     expect(response.status).to eq(401)
   end
@@ -41,4 +39,3 @@ end
 
 # return location and api key in body
 # Make serializer and render action.
-# favoriting locations, send it in the body, not the params

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -2,16 +2,15 @@ require 'rails_helper'
 
 describe 'Favorite Location API' do
   before :each do
-    @email = 'email@email.com'
     @password = 'password123'
     @api_key = "jgn983hy48thw9begh98h4539h4"
     @city = "Denver, CO"
 
-    @user1 = User.create!(email: @email, password: @password, password_confirmation: @password, api_key: @api_key)
-    @user2 = User.create!(email: @email, password: @password, password_confirmation: @password, api_key: 'different-key')
+    @user1 = User.create!(email: 'email@email.com', password: @password, password_confirmation: @password, api_key: @api_key)
+    @user2 = User.create!(email: 'different-email', password: @password, password_confirmation: @password, api_key: 'different-key')
   end
 
-  xit "receives a location & API key, then saves the location as the user's favorite" do
+  it "receives a location & API key, then saves the location as the user's favorite" do
     favorite_params = {"location": @city,
                         "api_key": @api_key}
 
@@ -19,10 +18,10 @@ describe 'Favorite Location API' do
 
     expect(response.status).to eq(204)
     expect(@user1.favorite_cities[0].city).to eq(@city)
-    expect(@user2.favorite_cities[0].city).to_not eq(@city)
+    expect(@user2.favorite_cities).to eq([])
   end
 
-  xit "receives a location & an incorrect API key, and does not save the location as a user's favorite" do
+  it "receives a location & an incorrect API key, and does not save the location as a user's favorite" do
     favorite_params = {"location": @city,
                         "api_key": "incorrect-key"}
 
@@ -31,7 +30,7 @@ describe 'Favorite Location API' do
     expect(response.status).to eq(401)
   end
 
-  xit "receives a location, but no API key, and does not save the location as a user's favorite" do
+  it "receives a location, but no API key, and does not save the location as a user's favorite" do
     favorite_params = {"location": @city}
 
     post '/api/v1/favorites', params: favorite_params
@@ -40,6 +39,5 @@ describe 'Favorite Location API' do
   end
 end
 
-# skipped tests seems to be failing and may need to integrate database cleaner
 # Why is it giving a 401 unauthorized in Postman
 # add to favorites controller ?  skip_before_action :verify_authenticity_token

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -1,26 +1,29 @@
 require 'rails_helper'
 
-desribe 'Favorite Location API' do
+describe 'Favorite Location API' do
   before :each do
-    @email = 'email'
+    @email = 'email@email.com'
     @password = 'password123'
     @api_key = "jgn983hy48thw9begh98h4539h4"
+    @city = "Denver, CO"
 
-    User.create!(email: @email, password: @password, password_confirmation: @password, api_key: @api_key)
+    @user1 = User.create!(email: @email, password: @password, password_confirmation: @password, api_key: @api_key)
+    @user2 = User.create!(email: @email, password: @password, password_confirmation: @password, api_key: 'different-key')
   end
 
   it "receives a location & API key, then saves the location as the user's favorite" do
-    favorite_params = {"location": "Denver, CO",
+    favorite_params = {"location": @city,
                         "api_key": @api_key}
 
     post '/api/v1/favorites', params: favorite_params
 
-    expect(response.status).to eq(200)
-    expect(response.status).to eq(200)
+    expect(response.status).to eq(204)
+    expect(@user1.favorite_cities[0].city).to eq(@city)
+    expect(@user2.favorite_cities[0].city).to_not eq(@city)
   end
 
   it "receives a location & an incorrect API key, and does not save the location as a user's favorite" do
-    favorite_params = {"location": "Denver, CO",
+    favorite_params = {"location": @city,
                         "api_key": "incorrect-key"}
 
     post '/api/v1/favorites', params: favorite_params
@@ -29,10 +32,15 @@ desribe 'Favorite Location API' do
   end
 
   it "receives a location, but no API key, and does not save the location as a user's favorite" do
-    favorite_params = {"location": "Denver, CO"}
+    favorite_params = {"location": @city}
 
     post '/api/v1/favorites', params: favorite_params
 
     expect(response.status).to eq(401)
   end
 end
+
+
+# test seems to be failing and may need to integrate database cleaner
+# Why is it giving a 401 unauthorized in Postman
+# add to favorites controller ?  skip_before_action :verify_authenticity_token

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -36,6 +36,3 @@ describe 'Favorite Location API' do
     expect(response.status).to eq(401)
   end
 end
-
-# return location and api key in body
-# Make serializer and render action.

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -11,7 +11,7 @@ describe 'Favorite Location API' do
     @user2 = User.create!(email: @email, password: @password, password_confirmation: @password, api_key: 'different-key')
   end
 
-  it "receives a location & API key, then saves the location as the user's favorite" do
+  xit "receives a location & API key, then saves the location as the user's favorite" do
     favorite_params = {"location": @city,
                         "api_key": @api_key}
 
@@ -22,7 +22,7 @@ describe 'Favorite Location API' do
     expect(@user2.favorite_cities[0].city).to_not eq(@city)
   end
 
-  it "receives a location & an incorrect API key, and does not save the location as a user's favorite" do
+  xit "receives a location & an incorrect API key, and does not save the location as a user's favorite" do
     favorite_params = {"location": @city,
                         "api_key": "incorrect-key"}
 
@@ -31,7 +31,7 @@ describe 'Favorite Location API' do
     expect(response.status).to eq(401)
   end
 
-  it "receives a location, but no API key, and does not save the location as a user's favorite" do
+  xit "receives a location, but no API key, and does not save the location as a user's favorite" do
     favorite_params = {"location": @city}
 
     post '/api/v1/favorites', params: favorite_params
@@ -40,7 +40,6 @@ describe 'Favorite Location API' do
   end
 end
 
-
-# test seems to be failing and may need to integrate database cleaner
+# skipped tests seems to be failing and may need to integrate database cleaner
 # Why is it giving a 401 unauthorized in Postman
 # add to favorites controller ?  skip_before_action :verify_authenticity_token

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -39,5 +39,6 @@ describe 'Favorite Location API' do
   end
 end
 
-# Why is it giving a 401 unauthorized in Postman
-# add to favorites controller ?  skip_before_action :verify_authenticity_token
+# return location and api key in body
+# Make serializer and render action.
+# favoriting locations, send it in the body, not the params

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+desribe 'Favorite Location API' do
+  before :each do
+    @email = 'email'
+    @password = 'password123'
+    @api_key = "jgn983hy48thw9begh98h4539h4"
+
+    User.create!(email: @email, password: @password, password_confirmation: @password, api_key: @api_key)
+  end
+
+  it "receives a location & API key, then saves the location as the user's favorite" do
+    favorite_params = {"location": "Denver, CO",
+                        "api_key": @api_key}
+
+    post '/api/v1/favorites', params: favorite_params
+
+    expect(response.status).to eq(200)
+    expect(response.status).to eq(200)
+  end
+
+  it "receives a location & an incorrect API key, and does not save the location as a user's favorite" do
+    favorite_params = {"location": "Denver, CO",
+                        "api_key": "incorrect-key"}
+
+    post '/api/v1/favorites', params: favorite_params
+
+    expect(response.status).to eq(401)
+  end
+
+  it "receives a location, but no API key, and does not save the location as a user's favorite" do
+    favorite_params = {"location": "Denver, CO"}
+
+    post '/api/v1/favorites', params: favorite_params
+
+    expect(response.status).to eq(401)
+  end
+end


### PR DESCRIPTION
This pull request completes the following specifications:

### Favoriting Locations

```
POST /api/v1/favorites
Content-Type: application/json
Accept: application/json

body:

{
  "location": "Denver, CO", # If you decide to store cities in your database you can send an id if you prefer
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
```

**Requirements:**

- API key must be sent
- If no API key or an incorrect key is provided return 401 (Unauthorized)