### PR TITLE
Iteration 6 - Removing Favorite Locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ POST /api/v1/users, params: { email: example@email.com, password: password123, p
 POST /api/v1/sessions, params: { email: example@email.com, password: password123 }
 POST /api/v1/favorites, body: {"location": "Denver, CO", "api_key": "jgn983hy48thw9begh98h4539h4"}
 GET /api/v1/favorites, body: {"api_key": "jgn983hy48thw9begh98h4539h4"}
+DELETE /api/v1/favorites, body: {"location": "Denver, CO", "api_key": "jgn983hy48thw9begh98h4539h4"}
 ```
 
 ## Tools

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,21 +1,26 @@
 class Api::V1::FavoritesController < ApiController
   def create
-    user = User.find_by(api_key: json_body[:api_key])
     if user
       FavoriteCity.create(user: user, city: json_body[:location])
     else
-      render json: {}, status: 401
+      render_401
     end
   end
 
   def index
-    user = User.find_by(api_key: json_body[:api_key])
     if user
       fav_cities_forecasts = FavoriteCitiesFacade.new(extract_city_names(user)).forecasts
-      # render json: FavoriteCitiesSerializer.new(fav_cities_forecasts)
       render json: fav_cities_forecasts, status: 200
     else
-      render json: {}, status: 401
+      render_401
+    end
+  end
+
+  def destroy
+    if user
+      json_body
+    else
+      render_401
     end
   end
 
@@ -28,5 +33,9 @@ class Api::V1::FavoritesController < ApiController
     user.favorite_cities.map do |fav_city|
       fav_city.city
     end.uniq
+  end
+
+  def user
+    User.find_by(api_key: json_body[:api_key])
   end
 end

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -18,7 +18,9 @@ class Api::V1::FavoritesController < ApiController
 
   def destroy
     if user
-      json_body
+      deleted_city = user.favorite_cities.find_by(city: json_body[:location]).destroy!
+      deleted_city_forecast = FavoriteCitiesFacade.new([deleted_city.city]).forecasts
+      render json: deleted_city_forecast, status: 200
     else
       render_401
     end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::SessionsController < ApiController
       session[:user_id] = user.id
       render json: UserSerializer.new(user)
     else
-      render json: {}, status: 401
+      render_401
     end
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,4 +1,7 @@
 class ApiController < ApplicationController
   protect_from_forgery with: :null_session
-  # skip_before_action :verify_authenticity_token
+
+  def render_401
+    render json: {}, status: 401
+  end
 end

--- a/app/facades/favorite_cities_facade.rb
+++ b/app/facades/favorite_cities_facade.rb
@@ -14,8 +14,8 @@ class FavoriteCitiesFacade
   private
   def coordinate_collection
     @cities.map do |city|
-      [ LocationService.new(city, nil, nil).coordinates[:lat],
-      LocationService.new(city, nil, nil).coordinates[:lng] ]
+      [ LocationService.new.location(city)[0],
+      LocationService.new.location(city)[1] ]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       get '/antipode', to: 'antipode#show'
       post '/favorites', to: 'favorites#create'
       get '/favorites', to: 'favorites#index'
+      delete '/favorites', to: 'favorites#destroy'
     end
   end
 end

--- a/spec/requests/api/v1/favorite_location_request_spec.rb
+++ b/spec/requests/api/v1/favorite_location_request_spec.rb
@@ -37,4 +37,16 @@ describe 'Favorite Location API' do
       expect(response.status).to eq(401)
     end
   end
+
+  context 'DELETE requests' do
+    it 'receives a location and valid API key and outputs the city_forecast that was deleted' do
+      body = {"location": "Denver, CO", "api_key": "jgn983hy48thw9begh98h4539h4"}
+
+      delete '/api/v1/favorites', params: body
+
+      expect(response.status).to eq(200)
+    end
+  end
 end
+
+#test for non valid and lack of api key


### PR DESCRIPTION
This pull request completes the following specifications:

### Removing Favorite Locations

```
DELETE /api/v1/favorites
Content-Type: application/json
Accept: application/json

body:

{
  "location": "Denver, CO", # If you decide to store cities in your database you can send an id if you prefer
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
```

**Requirements:**

- API key must be sent
- If no API key or an incorrect key is provided return 401 (Unauthorized)

**Response:**

```
status: 200
body:
[
  {
    "location": "Denver, CO",
    "current_weather": {
      # This can vary but try to keep it consistent with the
      # structure of the response from the /forecast endpoint
    }
  }
]
```